### PR TITLE
 Add CostCentre tag to all resources 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ See: https://learn.hashicorp.com/terraform/getting-started/install.html
 
 ## Running the Project
 
+This project bootstraps management account and environments, so it needs to be
+run from a development machine.
+
 1. Clone the project to local machine: https://github.com/nationalarchives/tdr-terraform-backend
 
 2. Add AWS credentials to the local credential store (~/.aws/credentials):

--- a/root.tf
+++ b/root.tf
@@ -1,7 +1,8 @@
 locals {
   common_tags = map(
     "Owner", "TDR Backend",
-    "Terraform", true
+    "Terraform", true,
+    "CostCentre", data.aws_ssm_parameter.cost_centre.value
   )
 }
 
@@ -19,6 +20,10 @@ data "aws_ssm_parameter" "prod_account_number" {
 
 data "aws_ssm_parameter" "mgmt_account_number" {
   name = "/mgmt/management_account"
+}
+
+data "aws_ssm_parameter" "cost_centre" {
+  name = "/mgmt/cost_centre"
 }
 
 terraform {


### PR DESCRIPTION
Add common tag for CostCentre so that Digital Services can identify our resources in the organisation's AWS bill.

Also add a note to the README to make it clearer that these Terraform scripts need to be run from a dev machine.