### PR TITLE
Add policy to role.

### DIFF
--- a/modules/specific-environment-permissions/environment_permissions.tf
+++ b/modules/specific-environment-permissions/environment_permissions.tf
@@ -44,6 +44,11 @@ resource "aws_iam_role" "jenkins_node_assume_role" {
   )
 }
 
+resource "aws_iam_role_policy_attachment" "jenkins_node_role_attachment" {
+  policy_arn = aws_iam_policy.jenkins_ecs_policy.arn
+  role       = aws_iam_role.jenkins_node_assume_role.name
+}
+
 resource "aws_iam_role" "jenkins_lambda_assume_role" {
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
   name               = "TDRJenkinsNodeLambdaRole${local.env_title_case}"


### PR DESCRIPTION
The role which the deployment containers use to deploy to ECS was
missing the policy which actually allows it to assume the role which
allows it to deploy, so none of the deployments were working. This puts
it back.