### PR TITLE
Add create policy version action

### DIFF
--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -70,7 +70,7 @@
         "iam:TagRole",
         "iam:UpdateAssumeRolePolicy",
         "iam:CreateServiceLinkedRole",
-	 "iam:CreatePolicyVersion"
+	    "iam:CreatePolicyVersion"
       ],
       "Resource": [
         "arn:aws:iam::${account_id}:policy/${app_name}_ecs_execution_policy_${environment}",

--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -69,7 +69,8 @@
         "iam:PassRole",
         "iam:TagRole",
         "iam:UpdateAssumeRolePolicy",
-        "iam:CreateServiceLinkedRole"
+        "iam:CreateServiceLinkedRole",
+	"iam:CreatePolicyVersion"
       ],
       "Resource": [
         "arn:aws:iam::${account_id}:policy/${app_name}_ecs_execution_policy_${environment}",

--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -70,7 +70,7 @@
         "iam:TagRole",
         "iam:UpdateAssumeRolePolicy",
         "iam:CreateServiceLinkedRole",
-	"iam:CreatePolicyVersion"
+	 "iam:CreatePolicyVersion"
       ],
       "Resource": [
         "arn:aws:iam::${account_id}:policy/${app_name}_ecs_execution_policy_${environment}",


### PR DESCRIPTION
I can't create a new S3 bucket with flow logs when the flow log
permissions already exist because it's missing this from the policy. This adds it
in.