### PR TITLE
New Keycloak client secret

### DIFF
--- a/modules/environment-roles/root.tf
+++ b/modules/environment-roles/root.tf
@@ -223,28 +223,7 @@ resource aws_iam_role_policy_attachment "tdr_jenkins_read_params_role_attach" {
 
 resource "aws_iam_policy" "tdr_jenkins_read_params_policy" {
   name   = "TDRJenkinsReadParams${title(var.tdr_environment)}"
-  policy = data.aws_iam_policy_document.tdr_jenkins_read_params.json
-}
-
-data "aws_iam_policy_document" "tdr_jenkins_read_params" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "ssm:DescribeParameters"
-    ]
-    resources = [
-      "*"
-    ]
-  }
-  statement {
-    effect = "Allow"
-    actions = [
-      "ssm:GetParameters"
-    ]
-    resources = [
-      "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/${var.tdr_environment}/keycloak/admin/*"
-    ]
-  }
+  policy = templatefile("${path.module}/templates/tdr_jenkins_read_params.json.tpl", { environment = var.tdr_environment, account_id = data.aws_caller_identity.current.account_id })
 }
 
 resource "aws_iam_role" "custodian_deploy_role" {

--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -165,7 +165,8 @@
         "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/${app_name}/admin/password",
         "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/${app_name}/admin/user",
         "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/${app_name}/client/secret",
-        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/${app_name}/backend_checks_client/secret"
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/${app_name}/backend_checks_client/secret",
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/${app_name}/realm_admin_client/secret"
       ]
     }
   ]

--- a/modules/environment-roles/templates/tdr_jenkins_read_params.json.tpl
+++ b/modules/environment-roles/templates/tdr_jenkins_read_params.json.tpl
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "ssm:DescribeParameters",
+      "Resource": "*"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameters",
+      "Resource": [
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/keycloak/admin/*",
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/keycloak/client/secret",
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/keycloak/backend_checks_client/secret",
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/keycloak/realm_admin_client/secret"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Additional Keycloak client added to update TDR realm configuration

New Keycloak client uses client secret

Client secret needs to be set in each TDR environment via Terraform role and read by Jenkins job to update the configuration