### PR TITLE
Mostly permissions for the download lambda.

### DIFF
--- a/modules/environment-roles/root.tf
+++ b/modules/environment-roles/root.tf
@@ -192,7 +192,10 @@ data "aws_iam_policy_document" "tdr_jenkins_lambda" {
       "arn:aws:s3:::tdr-backend-code-mgmt/*",
       "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:event-source-mapping:*",
       "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.current.account_id}:task-definition/file-format-build-${var.tdr_environment}",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/file_format_ecs_execution_role_${var.tdr_environment}"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/file_format_ecs_execution_role_${var.tdr_environment}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatECSExecutionRole${title(var.tdr_environment)}",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatEcsTaskRole${title(var.tdr_environment)}"
+
     ]
   }
   statement {

--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -118,6 +118,7 @@
         "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-yara-av-${environment}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-api-update-${environment}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-file-format-${environment}",
+        "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-download-files-${environment}",
         "arn:aws:lambda:eu-west-2:${account_id}:event-source-mapping:*"
 
       ]

--- a/modules/environment-roles/templates/shared_terraform_policy_2.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_2.json.tpl
@@ -88,7 +88,9 @@
         "arn:aws:iam::${account_id}:role/TDRFileFormatRole${environment}",
         "arn:aws:iam::${account_id}:policy/TDRFileFormatLambdaPolicy${environment}",
         "arn:aws:iam::${account_id}:policy/TDRFileFormatECSTaskPolicy${environment}",
-        "arn:aws:iam::${account_id}:policy/TDRFileFormatECSExecutionPolicy${environment}"
+        "arn:aws:iam::${account_id}:policy/TDRFileFormatECSExecutionPolicy${environment}",
+        "arn:aws:iam::${account_id}:policy/TDRDownloadFilesPolicy",
+        "arn:aws:iam::${account_id}:role/TDRDownloadFilesRole"
 
       ]
     },

--- a/modules/environment-roles/templates/shared_terraform_policy_3.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_3.json.tpl
@@ -172,6 +172,7 @@
         "elasticfilesystem:DescribeFileSystemPolicy",
         "elasticfilesystem:DescribeFileSystems",
         "elasticfilesystem:DescribeLifecycleConfiguration",
+        "elasticfilesystem:ModifyMountTargetSecurityGroups",
         "elasticfilesystem:PutFileSystemPolicy",
         "elasticfilesystem:PutLifecycleConfiguration"
       ],


### PR DESCRIPTION
There are permissions to access the new download files lambda. There's a
couple of other bits I noticed while I was doing it which I've lumped in
together.

Jenkins didn't have access to the file format build roles. I've no idea
how this used to work but it does now.

There was a permission missing that stopped us changing the mount target
security groups, I've added it in.