### PR TITLE
Remove Jenkins backup configuration

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -26,10 +26,6 @@ data "aws_ssm_parameter" "cost_centre" {
   name = "/mgmt/cost_centre"
 }
 
-data "aws_ssm_parameter" "jenkins_backup_healthcheck_url" {
-  name = "/mgmt/jenkins/backup/healthcheck/url"
-}
-
 terraform {
   backend "s3" {
     bucket         = "tdr-bootstrap-terraform-state"
@@ -315,21 +311,12 @@ module "ecr_image_scan_event" {
   rule_description           = "Capture each ECR Image Scan"
 }
 
-module "jenkins_maintenance_window_event" {
-  source                  = "./tdr-terraform-modules/cloudwatch_events"
-  event_pattern           = "jenkins_maintenance_event_window"
-  lambda_event_target_arn = module.ecr_image_scan_notification_lambda.ecr_scan_notification_lambda_arn
-  rule_name               = "jenkins-backup-maintenance-window"
-  rule_description        = "Capture failed runs of the jenkins backup"
-  event_variables         = { window_id = module.jenkins_backup_maintenance_window.window_id }
-}
-
 module "ecr_image_scan_notification_lambda" {
   source                        = "./tdr-terraform-modules/lambda"
   common_tags                   = local.common_tags
   project                       = "tdr"
   lambda_ecr_scan_notifications = true
-  event_rule_arns               = [module.jenkins_maintenance_window_event.event_arn, module.ecr_image_scan_event.event_arn]
+  event_rule_arns               = [module.ecr_image_scan_event.event_arn]
 }
 
 module "periodic_ecr_image_scan_lambda" {
@@ -346,12 +333,3 @@ module "periodic_ecr_image_scan_event" {
   rule_name               = "ecr-scan"
   lambda_event_target_arn = module.periodic_ecr_image_scan_lambda.ecr_scan_lambda_arn
 }
-
-module "jenkins_backup_maintenance_window" {
-  source        = "./tdr-terraform-modules/ssm_maintenance_window"
-  command       = "docker exec $(docker ps -aq -f ancestor=${data.aws_ssm_parameter.mgmt_account_number.value}.dkr.ecr.eu-west-2.amazonaws.com/jenkins) /opt/backup.sh ${data.aws_ssm_parameter.jenkins_backup_healthcheck_url.value}"
-  instance_name = "jenkins-task-definition-mgmt"
-  name          = "tdr-jenkins-backup-window"
-  schedule      = "cron(0 0 18 ? * MON-FRI *)"
-}
-


### PR DESCRIPTION
This is being moved to the tdr-jenkins repository. Configuring it in this repository caused a problem whenever the Jenkins EC2 instance was redeployed, because the maintenance window is linked directly to
the EC2 _instance_ ID. This meant that when you deploy the Jenkins EC2 instance, the backups fail because the maintenance windows tries to run the backups on the old instance.

Moving the configuration to the tdr-jenkins repo should fix the issue because we deploy a new EC2 instance by running the tdr-jenkins Terraform script. This should update link between the maintenance window and the EC2 instance whenever we deploy a new instance.