### PR TITLE
Renamed ssm param

### DIFF
--- a/modules/environment-roles/templates/shared_terraform_policy_2.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_2.json.tpl
@@ -16,10 +16,10 @@
           "ssm:GetParameter"
       ],
       "Resource" : [
+          "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/aws_elb_account",
           "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/cost_centre",
           "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/external_ips",
           "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/management_account",
-          "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/tna_organisation_root_account",
           "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/trusted_ips"
       ]
     },


### PR DESCRIPTION
Account number misidentified

SSM param name changed for account number to reflect what account number it is.