### PR TITLE
Temporarily reduce image scan frequency

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -337,7 +337,7 @@ module "periodic_ecr_image_scan_lambda" {
 
 module "periodic_ecr_image_scan_event" {
   source                  = "./tdr-terraform-modules/cloudwatch_events"
-  schedule                = "rate(2 days)"
+  schedule                = "rate(7 days)"
   rule_name               = "ecr-scan"
   lambda_event_target_arn = module.periodic_ecr_image_scan_lambda.ecr_scan_lambda_arn
 }


### PR DESCRIPTION
Run ECR image scans every 7 days instead of every 2 days to reduce noise from low-priority results over Christmas.

The service is not running in production yet, so it's OK if we don't get scan notifications as quickly right now.