### PR TITLE
Rename the lambda

### DIFF
--- a/modules/permissions/templates/jenkins_lambda_deploy_policy.json.tpl
+++ b/modules/permissions/templates/jenkins_lambda_deploy_policy.json.tpl
@@ -11,7 +11,7 @@
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-ecr-scan-notifications-${environment}",
+        "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-notifications-${environment}",
         "arn:aws:s3:::tdr-backend-code-${environment}/*"
       ]
     }

--- a/root.tf
+++ b/root.tf
@@ -321,17 +321,17 @@ module "ecr_image_scan_event" {
   source                     = "./tdr-terraform-modules/cloudwatch_events"
   event_pattern              = "ecr_image_scan"
   log_group_event_target_arn = module.ecr_image_scan_log_group.log_group_arn
-  lambda_event_target_arn    = module.ecr_image_scan_notification_lambda.ecr_scan_notification_lambda_arn
+  lambda_event_target_arn    = module.notification_lambda.ecr_scan_notification_lambda_arn
   rule_name                  = "ecr-image-scan"
   rule_description           = "Capture each ECR Image Scan"
 }
 
-module "ecr_image_scan_notification_lambda" {
+module "notification_lambda" {
   source                        = "./tdr-terraform-modules/lambda"
   common_tags                   = local.common_tags
   project                       = "tdr"
   lambda_ecr_scan_notifications = true
-  event_rule_arns               = [module.ecr_image_scan_event.event_arn]
+  event_rule_arns               = [module.ecr_image_scan_event.event_arn, "arn:aws:events:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:rule/jenkins-backup-maintenance-window"]
 }
 
 module "periodic_ecr_image_scan_lambda" {


### PR DESCRIPTION
The lambda module is no longer just doing ecr scans so I've renamed it. I've also added in the jenkins maintenance window event which is defined in the jenkins project. It's hard coded because there's no terraform data block for cloudwatch events.
