### PR TITLE
Add sns topic arns to the lambda module.

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -332,6 +332,7 @@ module "notification_lambda" {
   project                       = "tdr"
   lambda_ecr_scan_notifications = true
   event_rule_arns               = [module.ecr_image_scan_event.event_arn, "arn:aws:events:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:rule/jenkins-backup-maintenance-window"]
+  sns_topic_arns                = ["arn:aws:sns:eu-west-2:${data.aws_ssm_parameter.intg_account_number.value}:tdr-notifications-intg", "arn:aws:sns:eu-west-2:${data.aws_ssm_parameter.staging_account_number.value}:tdr-notifications-staging", "arn:aws:sns:eu-west-2:${data.aws_ssm_parameter.prod_account_number.value}:tdr-notifications-prod"]
 }
 
 module "periodic_ecr_image_scan_lambda" {


### PR DESCRIPTION
These sns topic arns are used inside the notifications lambda module to add permissions for these sns topics to invoke the lambda function.

The idea being that we will have one sns topic each for intg, staging and prod and these 3 will all connect to the notifications lambda in the management account. The arns are hardcoded because terraform doesn't have permissions to get them using a data block.
