### PR TITLE
Add a policy for Jenkins to check ami version.

### DIFF
--- a/modules/permissions/common_permissions.tf
+++ b/modules/permissions/common_permissions.tf
@@ -75,10 +75,10 @@ resource "aws_iam_role" "jenkins_check_ami_role" {
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
   name               = "TDRJenkinsCheckAmiRole"
   tags = merge(
-  var.common_tags,
-  map(
-  "Name", "TDR Jenkins Publish Role",
-  )
+    var.common_tags,
+    map(
+      "Name", "TDR Jenkins Publish Role",
+    )
   )
 }
 
@@ -89,7 +89,7 @@ resource "aws_iam_policy" "jenkins_check_ami_policy" {
 
 resource "aws_iam_role_policy_attachment" "jenkins_check_ami_policy_attachment" {
   policy_arn = aws_iam_policy.jenkins_check_ami_policy.arn
-  role = aws_iam_role.jenkins_check_ami_role.name
+  role       = aws_iam_role.jenkins_check_ami_role.name
 }
 
 resource "aws_iam_role" "jenkins_publish_role" {

--- a/modules/permissions/common_permissions.tf
+++ b/modules/permissions/common_permissions.tf
@@ -71,6 +71,27 @@ data "aws_iam_policy_document" "ecs_assume_role" {
   }
 }
 
+resource "aws_iam_role" "jenkins_check_ami_role" {
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+  name               = "TDRJenkinsCheckAmiRole"
+  tags = merge(
+  var.common_tags,
+  map(
+  "Name", "TDR Jenkins Publish Role",
+  )
+  )
+}
+
+resource "aws_iam_policy" "jenkins_check_ami_policy" {
+  name   = "TDRJenkinsCheckAmiPolicy"
+  policy = templatefile("${path.module}/templates/jenkins_check_ami_policy.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "jenkins_check_ami_policy_attachment" {
+  policy_arn = aws_iam_policy.jenkins_check_ami_policy.arn
+  role = aws_iam_role.jenkins_check_ami_role.name
+}
+
 resource "aws_iam_role" "jenkins_publish_role" {
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
   name               = "TDRJenkinsPublishRole"

--- a/modules/permissions/templates/jenkins_check_ami_policy.json.tpl
+++ b/modules/permissions/templates/jenkins_check_ami_policy.json.tpl
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DescribeImages",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::tdr-terraform-state-jenkins",
+        "arn:aws:s3:::tdr-terraform-state-jenkins/jenkins-terraform-state"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The s3 permissions are needed to access the terraform state file to get the current ami and the describe image permissions are to get the latest one.
