### PR TITLE
Add new API policy

### DIFF
--- a/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
@@ -85,7 +85,6 @@
         "arn:aws:iam::${account_id}:policy/TDRCreateDbUsersPolicy${environment}",
         "arn:aws:iam::${account_id}:role/TDRCreateDbUsersRole${environment}",
         "arn:aws:iam::${account_id}:policy/TDRConsignmentApiAllowIAMAuthPolicy${environment}"
-
       ]
     },
     {

--- a/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
@@ -83,7 +83,9 @@
         "arn:aws:iam::${account_id}:role/TDRConsignmentExportRole${environment}",
         "arn:aws:iam::${account_id}:policy/TDRConsignmentExportPolicy${environment}",
         "arn:aws:iam::${account_id}:policy/TDRCreateDbUsersPolicy${environment}",
-        "arn:aws:iam::${account_id}:role/TDRCreateDbUsersRole${environment}"
+        "arn:aws:iam::${account_id}:role/TDRCreateDbUsersRole${environment}",
+        "arn:aws:iam::${account_id}:policy/TDRConsignmentApiAllowIAMAuthPolicy${environment}"
+
       ]
     },
     {


### PR DESCRIPTION
This is the policy which is attached to the api ecs task role to allow
it to use iam auth on the db.
