### PR TITLE
Pass list of muted ECR alerts to notifications lambda 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.tfvars
 .DS_Store
 tdr-terraform-modules
+tdr-configurations

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ modules.
 Clone the [tdr-terraform-modules](https://github.com/nationalarchives/tdr-terraform-modules/)
 project into this project's directory.
 
+### Add TDR Configurations
+
+This project depends on non-public values configured in the TDR configurations
+project. Clone [tdr-configurations](https://github.com/nationalarchives/tdr-configurations)
+into this project's directory.
+
 ## Running the Project
 
 This project bootstraps management account and environments, so it needs to be

--- a/root.tf
+++ b/root.tf
@@ -26,6 +26,10 @@ data "aws_ssm_parameter" "cost_centre" {
   name = "/mgmt/cost_centre"
 }
 
+module "global_parameters" {
+  source = "./tdr-configurations/terraform"
+}
+
 terraform {
   backend "s3" {
     bucket         = "tdr-bootstrap-terraform-state"
@@ -333,6 +337,7 @@ module "notification_lambda" {
   lambda_ecr_scan_notifications = true
   event_rule_arns               = [module.ecr_image_scan_event.event_arn, "arn:aws:events:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:rule/jenkins-backup-maintenance-window"]
   sns_topic_arns                = ["arn:aws:sns:eu-west-2:${data.aws_ssm_parameter.intg_account_number.value}:tdr-notifications-intg", "arn:aws:sns:eu-west-2:${data.aws_ssm_parameter.staging_account_number.value}:tdr-notifications-staging", "arn:aws:sns:eu-west-2:${data.aws_ssm_parameter.prod_account_number.value}:tdr-notifications-prod"]
+  muted_scan_alerts             = module.global_parameters.muted_ecr_scan_alerts
 }
 
 module "periodic_ecr_image_scan_lambda" {


### PR DESCRIPTION
These are CVEs for which no fix is available, and which should be temporarily muted in the email and Slack alerts.

Need to merge two other PRs before this one:

- [x] https://github.com/nationalarchives/tdr-configurations/pull/58
- [x] https://github.com/nationalarchives/tdr-terraform-modules/pull/90