### PR TITLE
Allow lambda deployment jobs to deploy ECR scan lambda

### DIFF
--- a/modules/permissions/templates/jenkins_lambda_deploy_policy.json.tpl
+++ b/modules/permissions/templates/jenkins_lambda_deploy_policy.json.tpl
@@ -12,6 +12,7 @@
       ],
       "Resource": [
         "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-notifications-${environment}",
+        "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-ecr-scan-${environment}",
         "arn:aws:s3:::tdr-backend-code-${environment}/*"
       ]
     }


### PR DESCRIPTION
Fix the broken ECR scan deployment job on Jenkins, which did not have permission to deploy the ECR scan lambda.