### PR TITLE
Add permissions to create, delete and describe rules.

### DIFF
--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -28,8 +28,10 @@
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
         "elasticloadbalancing:DeleteListener",
         "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
         "elasticloadbalancing:DeleteTargetGroup",
         "elasticloadbalancing:DeregisterTargets",
         "elasticloadbalancing:ModifyListener",
@@ -45,7 +47,8 @@
         "arn:aws:elasticloadbalancing:eu-west-2:${account_id}:listener/net/tdr-${app_name}-${environment}/*/*",
         "arn:aws:elasticloadbalancing:eu-west-2:${account_id}:loadbalancer/net/tdr-${app_name}-${environment}/*",
         "arn:aws:elasticloadbalancing:eu-west-2:${account_id}:loadbalancer/app/tdr-${app_name}-${environment}/*",
-        "arn:aws:elasticloadbalancing:eu-west-2:${account_id}:targetgroup/*"
+        "arn:aws:elasticloadbalancing:eu-west-2:${account_id}:targetgroup/*",
+        "arn:aws:elasticloadbalancing:eu-west-2:${account_id}:listener-rule/app/tdr-keycloak-${environment}/*"
       ]
     },
     {

--- a/modules/environment-roles/templates/shared_terraform_policy_1.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_1.json.tpl
@@ -89,6 +89,7 @@
         "elasticloadbalancing:DescribeListeners",
         "elasticloadbalancing:DescribeLoadBalancerAttributes",
         "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeRules",
         "elasticloadbalancing:DescribeTags",
         "elasticloadbalancing:DescribeTargetGroupAttributes",
         "elasticloadbalancing:DescribeTargetGroups",


### PR DESCRIPTION
We've never actually used any load balancer rules, we've just used the default target. These permissions are needed now from the changes to keycloak's load balancer to only allow requests with the same host as itself.
