### PR TITLE
Add missing common_tags parameter

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -320,8 +320,9 @@ module "ecr_consignment_export_repository" {
 }
 
 module "ecr_image_scan_log_group" {
-  source = "./tdr-terraform-modules/cloudwatch_logs"
-  name   = "/aws/events/ecr-image-scans"
+  source      = "./tdr-terraform-modules/cloudwatch_logs"
+  name        = "/aws/events/ecr-image-scans"
+  common_tags = local.common_tags
 }
 
 module "ecr_image_scan_event" {


### PR DESCRIPTION
This mandatory parameter was added to the Cloudwatch logs module in a recent commit: https://github.com/nationalarchives/tdr-terraform-modules/commit/1f83113721cc65193716b21d63ca5e6a9c7edfea