### PR TITLE
Remove parameter store params which list trusted IPs

### DIFF
--- a/modules/environment-roles/templates/shared_terraform_policy_2.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_2.json.tpl
@@ -18,9 +18,7 @@
       "Resource" : [
           "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/aws_elb_account",
           "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/cost_centre",
-          "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/external_ips",
-          "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/management_account",
-          "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/trusted_ips"
+          "arn:aws:ssm:eu-west-2:${account_id}:parameter/mgmt/management_account"
       ]
     },
     {


### PR DESCRIPTION
These parameters are no longer used. The Terraform scripts which used to use them are now using the IP list in tdr-configurations instead, so these parameters will be deleted.