### PR TITLE
Add missing EFS TagResource permission to Jenkins

### DIFF
--- a/modules/environment-roles/templates/shared_terraform_policy_3.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_3.json.tpl
@@ -177,7 +177,8 @@
         "elasticfilesystem:DescribeLifecycleConfiguration",
         "elasticfilesystem:ModifyMountTargetSecurityGroups",
         "elasticfilesystem:PutFileSystemPolicy",
-        "elasticfilesystem:PutLifecycleConfiguration"
+        "elasticfilesystem:PutLifecycleConfiguration",
+        "elasticfilesystem:TagResource"
       ],
       "Resource": [
         "arn:aws:elasticfilesystem:eu-west-2:${account_id}:access-point/*",


### PR DESCRIPTION
The Jenkins tdr-terraform-environments deployment is currently failing because Jenkins does not have permission to update the tags for the EFS resources.