### PR TITLE
Move describe ec2 role from tdr-scripts terraform.

### DIFF
--- a/modules/environment-roles/root.tf
+++ b/modules/environment-roles/root.tf
@@ -367,3 +367,19 @@ resource "aws_iam_role_policy_attachment" "jenkins_export_s3_attach" {
   policy_arn = aws_iam_policy.jenkins_export_s3_policy[count.index].arn
   role       = aws_iam_role.jenkins_export_s3_role[count.index].id
 }
+
+
+resource "aws_iam_role" "jenkins_describe_ec2_role" {
+  name               = "TDRJenkinsDescribeEC2Role${title(var.tdr_environment)}"
+  assume_role_policy = templatefile("${path.module}/templates/terraform_assume_role_policy.json.tpl", { account_id = var.tdr_mgmt_account_number })
+}
+
+resource "aws_iam_policy" "jenkins_describe_ec2_policy" {
+  name   = "TDRJenkinsDescribeEC2Policy${title(var.tdr_environment)}"
+  policy = templatefile("${path.module}/templates/run_ec2_describe.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "jenkins_describe_ec2_attach" {
+  policy_arn = aws_iam_policy.jenkins_describe_ec2_policy.arn
+  role       = aws_iam_role.jenkins_describe_ec2_role.id
+}

--- a/modules/environment-roles/templates/run_ec2_describe.json.tpl
+++ b/modules/environment-roles/templates/run_ec2_describe.json.tpl
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DescribeInstances",
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
This is the role and policy which allows the job which checks the age of
a bastion and delete it if it is too old. The problem was that I had it
in the terraform for the bastion creation in the tdr-scripts project so
we could only check if the bastion was too old if it had already been
created which is less than ideal.
So these roles need to exist permanently so I've added them in here.
