### PR TITLE
Add permissions for creating athena workgroups

### DIFF
--- a/modules/environment-roles/root.tf
+++ b/modules/environment-roles/root.tf
@@ -106,7 +106,7 @@ resource "aws_iam_policy" "shared_terraform_policy_3" {
 }
 
 resource "aws_iam_policy" "shared_terraform_policy_4" {
-  policy = templatefile("${path.module}/templates/shared_terraform_policy_4.json.tpl", { environment = title(var.tdr_environment), account_id = data.aws_caller_identity.current.account_id, sub_domain = var.sub_domain })
+  policy = templatefile("${path.module}/templates/shared_terraform_policy_4.json.tpl", { environment = title(var.tdr_environment), account_id = data.aws_caller_identity.current.account_id, sub_domain = var.sub_domain, environment_lower = var.tdr_environment })
   name   = "TDRSharedTerraform4${title(var.tdr_environment)}"
 }
 

--- a/modules/environment-roles/root.tf
+++ b/modules/environment-roles/root.tf
@@ -106,7 +106,7 @@ resource "aws_iam_policy" "shared_terraform_policy_3" {
 }
 
 resource "aws_iam_policy" "shared_terraform_policy_4" {
-  policy = templatefile("${path.module}/templates/shared_terraform_policy_4.json.tpl", { environment = title(var.tdr_environment), account_id = data.aws_caller_identity.current.account_id, sub_domain = var.sub_domain, environment_lower = var.tdr_environment })
+  policy = templatefile("${path.module}/templates/shared_terraform_policy_4.json.tpl", { environment = title(var.tdr_environment), account_id = data.aws_caller_identity.current.account_id, sub_domain = var.sub_domain, environment_lower_case = var.tdr_environment })
   name   = "TDRSharedTerraform4${title(var.tdr_environment)}"
 }
 

--- a/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
@@ -112,7 +112,6 @@
       "Resource": [
         "arn:aws:states:eu-west-2:${account_id}:stateMachine:TDRConsignmentExport${environment}"
       ]
-
     },
     {
       "Effect": "Allow",
@@ -124,6 +123,34 @@
         "ec2:DeleteNetworkAclEntry"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "athena:CreateNamedQuery",
+        "athena:CreateWorkGroup",
+        "athena:DeleteNamedQuery",
+        "athena:DeleteWorkGroup",
+        "athena:GetNamedQuery",
+        "athena:GetQueryExecution",
+        "athena:GetQueryResults",
+        "athena:GetWorkGroup",
+        "athena:ListTagsForResource",
+        "athena:StartQueryExecution",
+        "athena:TagResource",
+        "glue:CreateDatabase",
+        "glue:DeleteDatabase",
+        "glue:GetDatabase",
+        "glue:GetDatabases",
+        "glue:GetTables"
+      ],
+      "Resource": [
+        "arn:aws:athena:eu-west-2:${account_id}:workgroup/*",
+        "arn:aws:glue:eu-west-2:${account_id}:catalog",
+        "arn:aws:glue:eu-west-2:${account_id}:database/tdr_security_logs_${environment_lower}",
+        "arn:aws:glue:eu-west-2:${account_id}:table/tdr_security_logs_${environment_lower}/*",
+        "arn:aws:glue:eu-west-2:${account_id}:userDefinedFunction/tdr_security_logs_${environment_lower}/*"
+      ]
     }
   ]
 }

--- a/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
@@ -147,9 +147,9 @@
       "Resource": [
         "arn:aws:athena:eu-west-2:${account_id}:workgroup/*",
         "arn:aws:glue:eu-west-2:${account_id}:catalog",
-        "arn:aws:glue:eu-west-2:${account_id}:database/tdr_security_logs_${environment_lower}",
-        "arn:aws:glue:eu-west-2:${account_id}:table/tdr_security_logs_${environment_lower}/*",
-        "arn:aws:glue:eu-west-2:${account_id}:userDefinedFunction/tdr_security_logs_${environment_lower}/*"
+        "arn:aws:glue:eu-west-2:${account_id}:database/tdr_security_logs_${environment_lower_case}",
+        "arn:aws:glue:eu-west-2:${account_id}:table/tdr_security_logs_${environment_lower_case}/*",
+        "arn:aws:glue:eu-west-2:${account_id}:userDefinedFunction/tdr_security_logs_${environment_lower_case}/*"
       ]
     }
   ]

--- a/modules/grafana/root.tf
+++ b/modules/grafana/root.tf
@@ -75,10 +75,10 @@ resource "aws_iam_policy" "shared_terraform_policy_4" {
   policy = templatefile(
     "./modules/environment-roles/templates/shared_terraform_policy_4.json.tpl",
     {
-      environment       = title(var.tdr_environment),
-      environment_lower = var.tdr_environment,
-      account_id        = var.tdr_mgmt_account_number,
-      sub_domain        = var.sub_domain
+      environment            = title(var.tdr_environment),
+      environment_lower_case = var.tdr_environment,
+      account_id             = var.tdr_mgmt_account_number,
+      sub_domain             = var.sub_domain
     }
   )
 }

--- a/modules/grafana/root.tf
+++ b/modules/grafana/root.tf
@@ -75,9 +75,10 @@ resource "aws_iam_policy" "shared_terraform_policy_4" {
   policy = templatefile(
     "./modules/environment-roles/templates/shared_terraform_policy_4.json.tpl",
     {
-      environment = title(var.tdr_environment),
-      account_id  = var.tdr_mgmt_account_number,
-      sub_domain  = var.sub_domain
+      environment       = title(var.tdr_environment),
+      environment_lower = var.tdr_environment,
+      account_id        = var.tdr_mgmt_account_number,
+      sub_domain        = var.sub_domain
     }
   )
 }


### PR DESCRIPTION
We're going to use the athena module in `tdr-terraform-modules` to
create athena work groups and named queries and these allow us to do it.

The glue permissions oddly are necessary.
https://docs.aws.amazon.com/athena/latest/ug/fine-grained-access-to-glue-resources.html#access-to-glue-resources-limitations
