### PR TITLE
Move permission to Keycloak ecs task policy

### DIFF
--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -80,6 +80,7 @@
       "Resource": [
         "arn:aws:iam::${account_id}:policy/${app_name}_ecs_execution_policy_${environment}",
         "arn:aws:iam::${account_id}:policy/${app_name}_ecs_task_policy_${environment}",
+        "arn:aws:iam::${account_id}:policy/TDRKeycloakECSTaskPolicy${environment}",
         "arn:aws:iam::${account_id}:policy/TDRKeycloakFlowlogPolicy${title(environment)}",
         "arn:aws:iam::${account_id}:policy/TDRVpcFlowlogPolicy${title(environment)}",
         "arn:aws:iam::${account_id}:role/${app_name}_ecs_execution_role_${environment}",

--- a/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
@@ -94,8 +94,7 @@
         "arn:aws:iam::${account_id}:role/TDRNotificationsLambdaRole${environment}",
         "arn:aws:iam::${account_id}:role/TDRServiceUnavailableRole${environment}",
         "arn:aws:iam::${account_id}:policy/TDRServiceUnavailablePolicy${environment}",
-        "arn:aws:iam::${account_id}:role/Custodian*",
-        "arn:aws:iam::${account_id}:policy/TDRKeycloakECSTaskPolicy${environment}"
+        "arn:aws:iam::${account_id}:role/Custodian*"
       ]
     },
     {


### PR DESCRIPTION
Adding permission to the 'shared_terraform_policy_4' caused the staging version to reach the IAM policy size limit. Other environment policies unaffected

Move the permissions to access the Keycloak ecs task policy to different file.