### PR TITLE
Permissions for terraform to setup Cloudfront proxy

### DIFF
--- a/modules/environment-roles/root.tf
+++ b/modules/environment-roles/root.tf
@@ -65,6 +65,11 @@ resource "aws_iam_role_policy_attachment" "shared_policy_attachment_4" {
   role       = aws_iam_role.terraform_role.name
 }
 
+resource "aws_iam_role_policy_attachment" "shared_policy_attachment_5" {
+  policy_arn = aws_iam_policy.shared_terraform_policy_5.arn
+  role       = aws_iam_role.terraform_role.name
+}
+
 resource "aws_iam_role_policy_attachment" "keycloak_policy_attachment" {
   role       = aws_iam_role.terraform_role.name
   policy_arn = aws_iam_policy.keycloak_terraform_iam.arn
@@ -108,6 +113,11 @@ resource "aws_iam_policy" "shared_terraform_policy_3" {
 resource "aws_iam_policy" "shared_terraform_policy_4" {
   policy = templatefile("${path.module}/templates/shared_terraform_policy_4.json.tpl", { environment = title(var.tdr_environment), account_id = data.aws_caller_identity.current.account_id, sub_domain = var.sub_domain, environment_lower_case = var.tdr_environment })
   name   = "TDRSharedTerraform4${title(var.tdr_environment)}"
+}
+
+resource "aws_iam_policy" "shared_terraform_policy_5" {
+  policy = templatefile("${path.module}/templates/shared_terraform_policy_5.json.tpl", { environment = title(var.tdr_environment), account_id = data.aws_caller_identity.current.account_id, sub_domain = var.sub_domain, environment_lower_case = var.tdr_environment })
+  name   = "TDRSharedTerraform5${title(var.tdr_environment)}"
 }
 
 resource "aws_iam_policy" "keycloak_terraform_iam" {

--- a/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/app_base_terraform_policy.json.tpl
@@ -136,6 +136,7 @@
         "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-create-keycloak-db-user-${environment}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-notifications-${environment}",
         "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-service-unavailable-${environment}",
+        "arn:aws:lambda:eu-west-2:${account_id}:function:tdr-sign-cookies-${environment}",
         "arn:aws:lambda:eu-west-2:${account_id}:event-source-mapping:*"
       ]
     },

--- a/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_4.json.tpl
@@ -94,35 +94,14 @@
         "arn:aws:iam::${account_id}:role/TDRNotificationsLambdaRole${environment}",
         "arn:aws:iam::${account_id}:role/TDRServiceUnavailableRole${environment}",
         "arn:aws:iam::${account_id}:policy/TDRServiceUnavailablePolicy${environment}",
-        "arn:aws:iam::${account_id}:role/Custodian*"
+        "arn:aws:iam::${account_id}:policy/TDRSignCookiesLambdaPolicy",
+        "arn:aws:iam::${account_id}:policy/TDRSignedCookiesAPIPolicy${environment}",
+        "arn:aws:iam::${account_id}:policy/TDRSignedCookiesAPICloudwatchPolicy${environment}",
+        "arn:aws:iam::${account_id}:role/Custodian*",
+        "arn:aws:iam::${account_id}:role/TDRSignedCookiesAPICloudwatchRole${environment}",
+        "arn:aws:iam::${account_id}:role/TDRSignedCookiesAPIRole${environment}",
+        "arn:aws:iam::${account_id}:role/TDRSignCookiesLambdaRole"
       ]
-    },
-    {
-      "Sid": "states",
-      "Effect": "Allow",
-      "Action" : [
-        "states:CreateStateMachine",
-        "states:UpdateStateMachine",
-        "states:DeleteStateMachine",
-        "states:TagResource",
-        "states:UntagResource",
-        "states:DescribeStateMachine",
-        "states:ListTagsForResource"
-      ],
-      "Resource": [
-        "arn:aws:states:eu-west-2:${account_id}:stateMachine:TDRConsignmentExport${environment}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateNetworkAcl",
-        "ec2:ReplaceNetworkAclAssociation",
-        "ec2:CreateNetworkAclEntry",
-        "ec2:ReplaceNetworkAclEntry",
-        "ec2:DeleteNetworkAclEntry"
-      ],
-      "Resource": "*"
     },
     {
       "Effect": "Allow",

--- a/modules/environment-roles/templates/shared_terraform_policy_5.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_5.json.tpl
@@ -4,6 +4,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "cloudfront:CreateCachePolicy",
         "cloudfront:CreateCloudFrontOriginAccessIdentity",
         "cloudfront:CreateKeyGroup",
         "cloudfront:CreateOriginRequestPolicy",
@@ -28,11 +29,10 @@
         "cloudfront:UpdateOriginRequestPolicy",
         "cloudfront:UpdatePublicKey",
         "ec2:CreateNetworkAcl",
-        "ec2:ReplaceNetworkAclAssociation",
         "ec2:CreateNetworkAclEntry",
-        "ec2:ReplaceNetworkAclEntry",
         "ec2:DeleteNetworkAclEntry",
-        "cloudfront:CreateCachePolicy"
+        "ec2:ReplaceNetworkAclAssociation",
+        "ec2:ReplaceNetworkAclEntry"
       ],
       "Resource": ["*"]
     },
@@ -63,12 +63,12 @@
       "Effect": "Allow",
       "Action" : [
         "states:CreateStateMachine",
-        "states:UpdateStateMachine",
         "states:DeleteStateMachine",
+        "states:DescribeStateMachine",
+        "states:ListTagsForResource",
         "states:TagResource",
         "states:UntagResource",
-        "states:DescribeStateMachine",
-        "states:ListTagsForResource"
+        "states:UpdateStateMachine"
       ],
       "Resource": [
         "arn:aws:states:eu-west-2:${account_id}:stateMachine:TDRConsignmentExport${environment}"

--- a/modules/environment-roles/templates/shared_terraform_policy_5.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_5.json.tpl
@@ -1,0 +1,78 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:CreateCloudFrontOriginAccessIdentity",
+        "cloudfront:CreateKeyGroup",
+        "cloudfront:CreateOriginRequestPolicy",
+        "cloudfront:CreatePublicKey",
+        "cloudfront:DeleteCachePolicy",
+        "cloudfront:DeleteCloudFrontOriginAccessIdentity",
+        "cloudfront:DeleteKeyGroup",
+        "cloudfront:DeleteOriginRequestPolicy",
+        "cloudfront:DeletePublicKey",
+        "cloudfront:GetCachePolicy",
+        "cloudfront:GetCloudFrontOriginAccessIdentity",
+        "cloudfront:GetKeyGroup",
+        "cloudfront:GetOriginRequestPolicy",
+        "cloudfront:GetPublicKey",
+        "cloudfront:ListCachePolicies",
+        "cloudfront:ListKeyGroups",
+        "cloudfront:ListPublicKeys",
+        "cloudfront:ListTagsForResource",
+        "cloudfront:UpdateCachePolicy",
+        "cloudfront:UpdateCloudFrontOriginAccessIdentity",
+        "cloudfront:UpdateKeyGroup",
+        "cloudfront:UpdateOriginRequestPolicy",
+        "cloudfront:UpdatePublicKey",
+        "ec2:CreateNetworkAcl",
+        "ec2:ReplaceNetworkAclAssociation",
+        "ec2:CreateNetworkAclEntry",
+        "ec2:ReplaceNetworkAclEntry",
+        "ec2:DeleteNetworkAclEntry",
+        "cloudfront:CreateCachePolicy"
+      ],
+      "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:CreateDistribution",
+        "cloudfront:DeleteDistribution",
+        "cloudfront:GetDistribution",
+        "cloudfront:TagResource",
+        "cloudfront:UpdateDistribution"
+      ],
+      "Resource": [
+        "arn:aws:cloudfront::${account_id}:distribution/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter"
+      ],
+      "Resource": [
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment_lower_case}/cloudfront/key/private"
+      ]
+    },
+    {
+      "Sid": "states",
+      "Effect": "Allow",
+      "Action" : [
+        "states:CreateStateMachine",
+        "states:UpdateStateMachine",
+        "states:DeleteStateMachine",
+        "states:TagResource",
+        "states:UntagResource",
+        "states:DescribeStateMachine",
+        "states:ListTagsForResource"
+      ],
+      "Resource": [
+        "arn:aws:states:eu-west-2:${account_id}:stateMachine:TDRConsignmentExport${environment}"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
These are the new permissions needed by terraform in order to set up the new Cloudfront proxy, the API gateway and the new Lambda.
