### PR TITLE
Missing permission to access the IAM support group

### DIFF
--- a/modules/environment-roles/templates/shared_iam_terraform_policy.json.tpl
+++ b/modules/environment-roles/templates/shared_iam_terraform_policy.json.tpl
@@ -36,6 +36,7 @@
         "iam:UpdateRole"
       ],
       "Resource": [
+        "arn:aws:iam::${account_id}:group/group/support",
         "arn:aws:iam::${account_id}:policy/consignmentapi_ecs_execution_policy_${environment}",
         "arn:aws:iam::${account_id}:policy/consignmentapi_ecs_task_policy_${environment}",
         "arn:aws:iam::${account_id}:policy/frontend_ecs_execution_policy_${environment}",


### PR DESCRIPTION
Changes already deployed

AWS accounts Terraform requires access to the IAM support group
