### PR TITLE
Add common secrets to repositories

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -38,6 +38,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/github" {
+  version = "4.20.1"
+  hashes = [
+    "h1:gLGJ7+Zp723X37xxkVPB0rnuHb867jrYOTcBMaLSjHs=",
+    "zh:0358b5488993709aca7307b6b164540a449f48c17ab84120ebe380655948a325",
+    "zh:07fa810fd2b3bdb0dba1f1d59facd579224498519f7fbc1bb957a583652b9abc",
+    "zh:177ee8110c554e8b87f18a1b0ae32e85ef9f3dc03b4435ad3c2d16caab129d75",
+    "zh:1bb38ced83ff635e8b5dc3319b6181884a85626319d7bfd2d214d7da7074053b",
+    "zh:40b16b2a88780dda697ecaaefaeb7b8231b264f7bc37df50a312da09bde5cc26",
+    "zh:429b3484d1f7e950159c8025b4ba5b38e2fa5220849ec154966112b1fe9a58f9",
+    "zh:5fc45f45a38ad498f478442bb7af7abf1721d52b582962ad035019b4d86265d0",
+    "zh:719dcbebbe2ed117f2d9b4c9a21366d99c4c6f432ca209fc4b92d1ced7ffecf5",
+    "zh:7c342bc8be070782f00b0697e18213c1c9142d36b347a80af9b3bf86d64a70c8",
+    "zh:919667f6939a89550476dbf66e0c5ff928d8d4488c67b5645eae631dd2c4588c",
+    "zh:aab776134cc5e3b9a58e7a4048cc5c9e65fe4ec1f3defea196c32f7957b6c45e",
+    "zh:acb5ea2145c53bad46fb16d81f23261f3357956e6ea6194c7ed51f531b98067a",
+    "zh:c74aa6cf60a30966a06834c1209363927cb899a94807089fafaa2838c6762851",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [

--- a/root.tf
+++ b/root.tf
@@ -33,6 +33,14 @@ data "aws_ssm_parameter" "cost_centre" {
   name = "/mgmt/cost_centre"
 }
 
+data "aws_ssm_parameter" "workflow_pat" {
+  name = "/mgmt/workflow_pat"
+}
+
+data "aws_ssm_parameter" "slack_webhook_url" {
+  name = "/mgmt/release/slack/webhook"
+}
+
 module "global_parameters" {
   source = "./tdr-configurations/terraform"
 }
@@ -418,4 +426,24 @@ module "github_oidc_provider" {
   thumbprint  = "6938fd4d98bab03faadb97b34396831e3780aea1"
   url         = "https://token.actions.githubusercontent.com"
   common_tags = local.common_tags
+}
+
+module "github_transfer_frontend_repository" {
+  source          = "./tdr-terraform-modules/github_repositories"
+  repository_name = "nationalarchives/tdr-transfer-frontend"
+  secrets = {
+    MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
+    WORKFLOW_PAT       = data.aws_ssm_parameter.workflow_pat.value
+    SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
+  }
+}
+
+module "github_consignment_api_repository" {
+  source          = "./tdr-terraform-modules/github_repositories"
+  repository_name = "nationalarchives/tdr-consignment-api"
+  secrets = {
+    MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
+    WORKFLOW_PAT       = data.aws_ssm_parameter.workflow_pat.value
+    SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
+  }
 }


### PR DESCRIPTION
These secrets don't change in different environments so they can be
added at the GitHub repository level rather than the environment level.
