### PR TITLE
Add repository permissions and logs for terraform GitHub actions.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,13 @@
+name: 'Terraform check'
+on:
+  push:
+  pull_request:
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  check:
+    uses: nationalarchives/tdr-github-actions/.github/workflows/terraform_check.yml@main
+    secrets:
+      MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/modules/specific-environment-permissions/outputs.tf
+++ b/modules/specific-environment-permissions/outputs.tf
@@ -1,0 +1,7 @@
+output "terraform_ecs_policy_arn" {
+  value = aws_iam_policy.terraform_ecs_policy.arn
+}
+
+output "access_terraform_state_arn" {
+  value = aws_iam_policy.access_terraform_state.arn
+}

--- a/root_github.tf
+++ b/root_github.tf
@@ -106,6 +106,15 @@ module "github_terraform_modules_repository" {
   }
 }
 
+module "github_terraform_backend_repository" {
+  source          = "./tdr-terraform-modules/github_repositories"
+  repository_name = "nationalarchives/tdr-terraform-backend"
+  secrets = {
+    MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
+    WORKFLOW_PAT       = data.aws_ssm_parameter.workflow_pat.value
+  }
+}
+
 module "github_cloudwatch_terraform_plan_outputs_intg" {
   source      = "../tdr-terraform-modules/cloudwatch_logs"
   common_tags = local.common_tags

--- a/root_github.tf
+++ b/root_github.tf
@@ -86,9 +86,19 @@ module "github_checksum_repository" {
   }
 }
 
-module "github_terraform_repository" {
+module "github_terraform_environments_repository" {
   source          = "./tdr-terraform-modules/github_repositories"
   repository_name = "nationalarchives/tdr-terraform-environments"
+  secrets = {
+    MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
+    SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
+    WORKFLOW_PAT       = data.aws_ssm_parameter.workflow_pat.value
+  }
+}
+
+module "github_terraform_modules_repository" {
+  source          = "./tdr-terraform-modules/github_repositories"
+  repository_name = "nationalarchives/tdr-terraform-modules"
   secrets = {
     MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
     SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value

--- a/templates/iam_policy/github_cloudwatch_policy.json.tpl
+++ b/templates/iam_policy/github_cloudwatch_policy.json.tpl
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "logs:CreateLogStream",
+      "Resource": "arn:aws:logs:eu-west-2:${account_id}:log-group:terraform-plan-outputs-*"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "logs:PutLogEvents",
+      "Resource": "arn:aws:logs:eu-west-2:${account_id}:log-group:terraform-plan-outputs-*:log-stream:*"
+    }
+  ]
+}


### PR DESCRIPTION
This is:
* Roles to run terraform from GitHub actions
* Log groups to write the terraform plan logs to
* Secrets for the terraform environment and modules repos.