### PR TITLE
Add GPG secrets.

### DIFF
--- a/root_github.tf
+++ b/root_github.tf
@@ -342,6 +342,8 @@ module "github_backend_checks_performance_repository" {
     SANDBOX_ACCOUNT    = data.aws_ssm_parameter.sandbox_account_number.value
     WORKFLOW_PAT       = data.aws_ssm_parameter.workflow_pat.value
     SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
+    GPG_PASSPHRASE     = data.aws_ssm_parameter.gpg_passphrase.value
+    GPG_PRIVATE_KEY    = data.aws_ssm_parameter.gpg_key.value
   }
 }
 

--- a/root_github.tf
+++ b/root_github.tf
@@ -352,6 +352,8 @@ module "github_scripts_repository" {
     MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
     WORKFLOW_PAT       = data.aws_ssm_parameter.workflow_pat.value
     SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
+    GPG_PASSPHRASE     = data.aws_ssm_parameter.gpg_passphrase.value
+    GPG_PRIVATE_KEY    = data.aws_ssm_parameter.gpg_key.value
   }
 }
 


### PR DESCRIPTION
The GitHub release summary is committing to the repository so it needs
gpg to sign the commits.
