### PR TITLE
Update SLACK_WEBHOOK for tdr-scripts.

### DIFF
--- a/root_data.tf
+++ b/root_data.tf
@@ -30,6 +30,10 @@ data "aws_ssm_parameter" "slack_webhook_url" {
   name = "/mgmt/release/slack/webhook"
 }
 
+data "aws_ssm_parameter" "slack_notifications_webhook_url" {
+  name = "/mgmt/slack/notifications/webhook"
+}
+
 data "aws_ssm_parameter" "slack_pr_monitor_url" {
   name = "/mgmt/pr_monitor/slack/webhook"
 }

--- a/root_github.tf
+++ b/root_github.tf
@@ -359,7 +359,7 @@ module "github_scripts_repository" {
   secrets = {
     MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
     WORKFLOW_PAT       = data.aws_ssm_parameter.workflow_pat.value
-    SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
+    SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_notifications_webhook_url.value
     GPG_PASSPHRASE     = data.aws_ssm_parameter.gpg_passphrase.value
     GPG_PRIVATE_KEY    = data.aws_ssm_parameter.gpg_key.value
     SLACK_BOT_TOKEN    = data.aws_ssm_parameter.slack_bot_token.value


### PR DESCRIPTION
This means that the bastion notifications and the release summary will
now go to da-tdr-notifications.
