### PR TITLE
Add missing terraform permission.

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -55,6 +55,7 @@ provider "registry.terraform.io/hashicorp/github" {
     "zh:8a3abc6f6fadd99963ad9a593893b724ec2c98905f66fd1f627ca3aa55191dde",
     "zh:a0653c831705804d98db9d352341fee04ea6c7db6fa612f886b7284ce8a67023",
     "zh:a9b51b0c2e5026a4676b5ac71274eaa745ebef1de72a69667855edb8a9548347",
+    "zh:d7720e30f931f4069255e8d9d08332ccc2ee18b418e899fed55cd4f414f17bb6",
   ]
 }
 

--- a/modules/environment-roles/templates/shared_terraform_policy_1.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_1.json.tpl
@@ -71,6 +71,7 @@
         "ec2:DisassociateRouteTable",
         "ec2:ImportKeyPair",
         "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:ModifySecurityGroupRules",
         "ec2:ModifySubnetAttribute",
         "ec2:ModifyVpcAttribute",
         "ec2:ModifyVpcEndpoint",

--- a/modules/environment-roles/templates/shared_terraform_policy_1.json.tpl
+++ b/modules/environment-roles/templates/shared_terraform_policy_1.json.tpl
@@ -59,6 +59,7 @@
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSecurityGroupRules",
         "ec2:DescribeSubnets",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",


### PR DESCRIPTION
I've updated the AWS provider in tdr-terraform-environments and it's now making this new API call that it wasn't before so we need two more permissions. There is an [AWS blog post](https://aws.amazon.com/blogs/aws/easily-manage-security-group-rules-with-the-new-security-group-rule-id/) about it.

It's also updated the lock file in this project, I don't know why.
