### PR TITLE
Add external ID to secrets.

### DIFF
--- a/root_github.tf
+++ b/root_github.tf
@@ -370,9 +370,10 @@ module "github_aws_accounts_repository" {
   source          = "./tdr-terraform-modules/github_repositories"
   repository_name = "nationalarchives/tdr-aws-accounts"
   secrets = {
-    MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
-    SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
-    WORKFLOW_PAT       = module.common_ssm_parameters.params[local.github_access_token_name].value
+    MANAGEMENT_ACCOUNT    = data.aws_ssm_parameter.mgmt_account_number.value
+    SLACK_WEBHOOK         = data.aws_ssm_parameter.slack_webhook_url.value
+    WORKFLOW_PAT          = module.common_ssm_parameters.params[local.github_access_token_name].value
+    TERRAFORM_EXTERNAL_ID = module.global_parameters.external_ids.terraform_environments
   }
 }
 


### PR DESCRIPTION
The terraform role is mostly used by terraform which can access the
global parameters directly but there is one python script in
tdr-aws-accounts which needs it and it's difficult to get it from
terraform so I'm adding it in here.
