### PR TITLE
Provide scripts role with wider ec2 permissions

### DIFF
--- a/modules/environment-roles/templates/terraform_scripts_policy.json.tpl
+++ b/modules/environment-roles/templates/terraform_scripts_policy.json.tpl
@@ -110,30 +110,7 @@
       "Sid": "",
       "Effect": "Allow",
       "Action": [
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:CopyImage",
-        "ec2:CreateTags",
-        "ec2:DeleteKeyPair",
-        "ec2:DeleteSnapshot",
-        "ec2:DeregisterImage",
-        "ec2:DescribeAccountAttributes",
-        "ec2:DescribeIamInstanceProfileAssociations",
-        "ec2:DescribeImages",
-        "ec2:DescribeInstanceAttribute",
-        "ec2:DescribeInstanceCreditSpecifications",
-        "ec2:DescribeInstances",
-        "ec2:DescribeKeyPairs",
-        "ec2:DescribeNetworkInterfaces",
-        "ec2:DescribeSecurityGroups",
-        "ec2:DescribeSubnets",
-        "ec2:DescribeTags",
-        "ec2:DescribeVolumes",
-        "ec2:DescribeVpcAttribute",
-        "ec2:DescribeVpcs",
-        "ec2:ImportKeyPair",
-        "ec2:RevokeSecurityGroupIngress",
-        "ec2:RunInstances",
-        "ec2:TerminateInstances",
+        "ec2:*",
         "kms:CreateKey",
         "kms:ListAliases",
         "kms:ListKeys",
@@ -143,20 +120,6 @@
         "sts:GetCallerIdentity"
       ],
       "Resource": "*"
-    },
-    {
-      "Sid":  "",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AuthorizeSecurityGroupEgress",
-        "ec2:CreateSecurityGroup",
-        "ec2:DeleteSecurityGroup",
-        "ec2:RevokeSecurityGroupEgress"
-      ],
-      "Resource": [
-        "arn:aws:ec2:eu-west-2:${account_id}:security-group/*",
-        "arn:aws:ec2:eu-west-2:${account_id}:vpc/*"
-      ]
     },
     {
       "Sid": "",


### PR DESCRIPTION
Latest version of aws provider appears to require wider set of permissions to create ec2 instance and security groups

Give scripts role complete ec2 permissions