### PR TITLE
Place holder value causes error

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -366,8 +366,6 @@ module "notification_lambda" {
   sns_topic_arns                = [module.notifications_topic.sns_arn]
   muted_scan_alerts             = module.global_parameters.muted_ecr_scan_alerts
   kms_key_arn                   = module.mgmt_encryption_key.kms_key_arn
-  #  lambda policy requires key arn, but not applicable for the mgmt account
-  kms_export_bucket_key_arn = "no s3Bucket KMS key required for mgmt account - placeholder value"
 }
 
 module "mgmt_encryption_key" {


### PR DESCRIPTION
Requires PR: https://github.com/nationalarchives/tdr-terraform-modules/pull/257

Value in policy needs to be an arn or wildcard

Instead have separate IAM policy for s3 bucket KMS key permissions and don't apply to mgmt version of notifications lambda