### PR TITLE
remove deprecated attributes

### DIFF
--- a/modules/state/s3.tf
+++ b/modules/state/s3.tf
@@ -1,18 +1,5 @@
 resource "aws_s3_bucket" "tdr_terraform_state" {
   bucket = "tdr-terraform-state"
-  acl    = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  versioning {
-    enabled = true
-  }
 
   tags = merge(
     var.common_tags,
@@ -20,6 +7,29 @@ resource "aws_s3_bucket" "tdr_terraform_state" {
       { "Name" = "TDR Terraform State" }
     )
   )
+}
+
+resource "aws_s3_bucket_acl" "tdr_terraform_state_acl" {
+  bucket = aws_s3_bucket.tdr_terraform_state.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tdr_terraform_state_encryption" {
+  bucket = aws_s3_bucket.tdr_terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tdr_terraform_state_versioning" {
+  bucket = aws_s3_bucket.tdr_terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access_block" {
@@ -33,19 +43,6 @@ resource "aws_s3_bucket_public_access_block" "public_access_block" {
 
 resource "aws_s3_bucket" "tdr_terraform_state_jenkins" {
   bucket = "tdr-terraform-state-jenkins"
-  acl    = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  versioning {
-    enabled = true
-  }
 
   tags = merge(
     var.common_tags,
@@ -54,6 +51,30 @@ resource "aws_s3_bucket" "tdr_terraform_state_jenkins" {
     )
   )
 }
+
+resource "aws_s3_bucket_acl" "tdr_terraform_state_jenkins_acl" {
+  bucket = aws_s3_bucket.tdr_terraform_state_jenkins.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tdr_terraform_state_jenkins_encryption" {
+  bucket = aws_s3_bucket.tdr_terraform_state_jenkins.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tdr_terraform_state_jenkins_versioning" {
+  bucket = aws_s3_bucket.tdr_terraform_state_jenkins.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 
 resource "aws_s3_bucket_public_access_block" "public_access_block_jenkins" {
   bucket = aws_s3_bucket.tdr_terraform_state_jenkins.id
@@ -66,19 +87,6 @@ resource "aws_s3_bucket_public_access_block" "public_access_block_jenkins" {
 
 resource "aws_s3_bucket" "tdr_terraform_state_grafana" {
   bucket = "tdr-terraform-state-grafana"
-  acl    = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  versioning {
-    enabled = true
-  }
 
   tags = merge(
     var.common_tags,
@@ -86,6 +94,29 @@ resource "aws_s3_bucket" "tdr_terraform_state_grafana" {
       { "Name" = "TDR Grafana Terraform State" }
     )
   )
+}
+
+resource "aws_s3_bucket_acl" "tdr_terraform_state_grafana_acl" {
+  bucket = aws_s3_bucket.tdr_terraform_state_grafana.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tdr_terraform_state_grafana_encryption" {
+  bucket = aws_s3_bucket.tdr_terraform_state_grafana.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tdr_terraform_state_grafana_versioning" {
+  bucket = aws_s3_bucket.tdr_terraform_state_grafana.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access_block_grafana" {
@@ -100,19 +131,6 @@ resource "aws_s3_bucket_public_access_block" "public_access_block_grafana" {
 
 resource "aws_s3_bucket" "tdr_terraform_state_scripts" {
   bucket = "tdr-terraform-state-scripts"
-  acl    = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  versioning {
-    enabled = true
-  }
 
   tags = merge(
     var.common_tags,
@@ -120,6 +138,29 @@ resource "aws_s3_bucket" "tdr_terraform_state_scripts" {
       { "Name" = "TDR Scripts Terraform State" }
     )
   )
+}
+
+resource "aws_s3_bucket_acl" "tdr_terraform_state_scripts_acl" {
+  bucket = aws_s3_bucket.tdr_terraform_state_scripts.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tdr_terraform_state_scripts_encryption" {
+  bucket = aws_s3_bucket.tdr_terraform_state_scripts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tdr_terraform_state_scripts_versioning" {
+  bucket = aws_s3_bucket.tdr_terraform_state_scripts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access_block_scripts" {
@@ -134,26 +175,35 @@ resource "aws_s3_bucket_public_access_block" "public_access_block_scripts" {
 resource "aws_s3_bucket" "tdr_terraform_state_github" {
   bucket = "tdr-terraform-state-github"
 
-  acl = "private"
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  versioning {
-    enabled = true
-  }
-
   tags = merge(
     var.common_tags,
     tomap(
       { "Name" = "TDR Github Terraform State" }
     )
   )
+}
+
+resource "aws_s3_bucket_acl" "tdr_terraform_state_github_acl" {
+  bucket = aws_s3_bucket.tdr_terraform_state_github.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tdr_terraform_state_github_encryption" {
+  bucket = aws_s3_bucket.tdr_terraform_state_github.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tdr_terraform_state_github_versioning" {
+  bucket = aws_s3_bucket.tdr_terraform_state_github.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access_block_github" {


### PR DESCRIPTION
```
resource "aws_s3_bucket" "tdr_terraform_state

resource "aws_s3_bucket" "tdr_terraform_state_jenkins

resource "aws_s3_bucket" "tdr_terraform_state_grafana"

resource "aws_s3_bucket" "tdr_terraform_state_scripts"

resource "aws_s3_bucket" "tdr_terraform_state_github"
```

**acl Argument:**

The acl argument is deprecated in favour of using the bucket_acl resource 

**Server-Side Encryption Configuration:**

The server_side_encryption_configuration block should now use the aws_s3_bucket_server_side_encryption_configuration resource instead of being part of the aws_s3_bucket resource.

**Versioning Configuration:**

The versioning block remains valid but can be split out into aws_s3_bucket_versioning.