### PR TITLE
Tdrd 825/allow terraform deploy role to delete s3 terraform lock files

### DIFF
--- a/modules/permissions/common_permissions.tf
+++ b/modules/permissions/common_permissions.tf
@@ -33,6 +33,12 @@ data "aws_iam_policy_document" "terraform_state_lock" {
     actions   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem"]
     resources = [var.terraform_state_lock, var.terraform_scripts_state_lock, var.terraform_github_state_lock]
   }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:DeleteObject"]
+    resources = ["${var.terraform_state_bucket}/*/*.tflock"]
+  }
 }
 
 resource "aws_iam_policy" "terraform_state_lock_access" {
@@ -48,12 +54,6 @@ data "aws_iam_policy_document" "terraform_describe_account" {
     effect    = "Allow"
     actions   = ["ec2:DescribeAccountAttributes", "ec2:DescribeAvailabilityZones"]
     resources = ["*"]
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["s3:DeleteObject"]
-    resources = ["${var.terraform_state_bucket}/*/*.tflock"]
   }
 }
 

--- a/modules/permissions/common_permissions.tf
+++ b/modules/permissions/common_permissions.tf
@@ -49,6 +49,12 @@ data "aws_iam_policy_document" "terraform_describe_account" {
     actions   = ["ec2:DescribeAccountAttributes", "ec2:DescribeAvailabilityZones"]
     resources = ["*"]
   }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:DeleteObject"]
+    resources = ["${var.terraform_state_bucket}/*/*.tflock"]
+  }
 }
 
 resource "aws_iam_policy" "terraform_describe_account" {


### PR DESCRIPTION
At least the reference generator repo is using this role to deploy in the github action.  To use the S3 lockfile in TF, it needs to be able to delete the S3 lockfile to release the lock.  Have deployed and is working e.g here it work https://github.com/nationalarchives/da-reference-generator/actions/runs/16032710727

here where it doesn't have the permission and then fails
https://github.com/nationalarchives/da-reference-generator/actions/runs/16030799032/job/45230609785