### PR TITLE
fix: Allow this role to use delete the lockfile for the tdr_scripts stacks

### DIFF
--- a/modules/permissions/common_permissions.tf
+++ b/modules/permissions/common_permissions.tf
@@ -35,9 +35,12 @@ data "aws_iam_policy_document" "terraform_state_lock" {
   }
 
   statement {
-    effect    = "Allow"
-    actions   = ["s3:DeleteObject"]
-    resources = ["${var.terraform_state_bucket}/*/*.tflock"]
+    effect  = "Allow"
+    actions = ["s3:DeleteObject"]
+    resources = [
+      "${var.terraform_state_bucket}/*/*.tflock",
+      "${var.terraform_scripts_state_bucket}/*/*.tflock"
+    ]
   }
 }
 


### PR DESCRIPTION
As before for the other stack, the tdr_scripts stacks (e.g. bastion) need to be able to delete S3 lockfile.  This is live btw.

